### PR TITLE
feat(widget-docs): add playground section for ui-sdk

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -170,6 +170,7 @@
             "technical-guides/aggregator-widget/introduction",
             "technical-guides/aggregator-widget/configuration",
             "technical-guides/aggregator-widget/events-feature",
+            "technical-guides/aggregator-widget/playground",
             {
               "group": "Advanced Configuration",
               "icon": "robot",

--- a/technical-guides/aggregator-widget/playground.mdx
+++ b/technical-guides/aggregator-widget/playground.mdx
@@ -1,0 +1,45 @@
+---
+title: 'Playground'
+description: 'Interactive playground for testing Swap Widget'
+icon: 'code'
+---
+
+## Overview
+
+Our playground allows you to quickly test the **Swap Widget** without setting up your own project. Here you can:
+
+- **View demo**: See the widget working in real-time
+- **Test features**: Try all core widget capabilities
+- **Experiment with settings**: Change themes, languages, and other parameters
+- **View code**: See integration examples
+
+## Launch Playground
+
+Click the button to open the playground in a new window 
+
+<p align="center">
+  <a href="https://stackblitz.com/github/vladi4kai/swap-sdk-playground/tree/main" target="_blank">
+    <img src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" />
+  </a>
+</p>
+
+## What's Included
+
+### 🚀 Quick Start
+The playground includes a fully configured project with:
+- Installed `@swap-coffee/ui-sdk`
+- Basic widget configuration
+- Wallet connection examples via TonConnect
+
+## Additional Resources
+
+- **[Introduction](/technical-guides/aggregator-widget/introduction)** - Detailed feature overview
+- **[Configuration](/technical-guides/aggregator-widget/configuration)** - Step-by-step setup
+- **[GitHub Repository](https://github.com/vladi4kai/swap-sdk-playground)** - Playground source code
+
+## Support
+
+If you have questions or issues with the playground:
+- Check the [documentation](/technical-guides/aggregator-widget/introduction)
+- Create an issue in the [GitHub repository](https://github.com/vladi4kai/swap-sdk-playground/issues)
+- Contact our support team


### PR DESCRIPTION
Add playground page with widget stackblitz integration as test playground